### PR TITLE
[codex] add native swipe-back option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Framework-agnostic page transitions for Capacitor apps. iOS-style navigation wit
 - **No Design Opinions** - Just transition logic, you bring your own styles
 - **Coordinated Transitions** - Header, content, and footer animate together
 - **Page Caching** - Keep pages in DOM for instant back navigation
-- **Native iOS Swipe Back** - Optional edge-swipe back gesture with Capacitor native runtime detection
+- **Ionic-style iOS Swipe Back** - Optional edge gesture with Capacitor native iOS auto-enable
 - **Lifecycle Hooks** - willEnter, didEnter, willLeave, didLeave events
 
 ## Compatibility
@@ -77,7 +77,7 @@ function App() {
 
   useEffect(() => {
     if (outletRef.current) {
-      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeBack: 'auto' });
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeGesture: 'auto' });
     }
   }, []);
 
@@ -291,26 +291,22 @@ export class HomeComponent {
 
 Container for page transitions.
 
-| Attribute     | Type                           | Default          | Description                                                                |
-| ------------- | ------------------------------ | ---------------- | -------------------------------------------------------------------------- |
-| `platform`    | `'ios' \| 'android' \| 'auto'` | `'auto'`         | Animation style                                                            |
-| `duration`    | `number`                       | Platform default | Animation duration in ms                                                   |
-| `keep-in-dom` | `boolean`                      | `true`           | Keep pages in DOM after navigating away                                    |
-| `max-cached`  | `number`                       | `10`             | Maximum pages to keep cached                                               |
-| `swipe-back`  | `boolean \| 'auto'`            | `'auto'`         | Enable edge swipe-back. `'auto'` enables only in native iOS Capacitor apps |
+| Attribute       | Type                           | Default          | Description                                                                        |
+| --------------- | ------------------------------ | ---------------- | ---------------------------------------------------------------------------------- |
+| `platform`      | `'ios' \| 'android' \| 'auto'` | `'auto'`         | Animation style                                                                    |
+| `duration`      | `number`                       | Platform default | Animation duration in ms                                                           |
+| `keep-in-dom`   | `boolean`                      | `true`           | Keep pages in DOM after navigating away                                            |
+| `max-cached`    | `number`                       | `10`             | Maximum pages to keep cached                                                       |
+| `swipe-gesture` | `boolean \| 'auto'`            | `'auto'`         | Enable edge swipe-back gesture. `'auto'` enables only in native iOS Capacitor apps |
 
 Methods:
 
 - `push(element, config?)` - Navigate forward to new page
 - `pop(config?)` - Navigate back
 - `setRoot(element, config?)` - Replace navigation stack
-- `setSwipeBack(true | false | 'auto')` - Enable, disable, or native-detect edge swipe-back
+- `setSwipeGesture(true | false | 'auto')` - Enable, disable, or auto-detect edge swipe-back gesture
 
-Events:
-
-- `cap-swipe-back` - Fired when an edge swipe-back gesture commits. The event is cancelable; call `event.preventDefault()` and perform your own router back action to override the default `window.history.back()` fallback.
-
-`swipe-back="auto"` uses Capacitor's runtime helpers (`Capacitor.isNativePlatform()` and `Capacitor.getPlatform()`) and enables the gesture only for native iOS apps. Use `swipe-back="true"` to force it on any platform or `swipe-back="false"` to disable it.
+`swipe-gesture="auto"` uses Capacitor's runtime helpers (`Capacitor.isNativePlatform()` and `Capacitor.getPlatform()`) and enables the gesture only for native iOS apps. Use `swipe-gesture="true"` to force it on any platform or `swipe-gesture="false"` to disable it.
 
 #### `<cap-page>`
 
@@ -364,18 +360,12 @@ setDirection('forward' | 'back' | 'root' | 'none');
 // Set up a router outlet element
 setupRouterOutlet(element, options);
 
-// Enable native-detected iOS edge swipe-back (default)
-setupRouterOutlet(element, { swipeBack: 'auto' });
+// Auto-enable the iOS edge swipe-back gesture in native Capacitor iOS apps
+setupRouterOutlet(element, { swipeGesture: 'auto' });
 
 // Force enable or disable from JavaScript
-setupRouterOutlet(element, { swipeBack: true });
-setupRouterOutlet(element, { swipeBack: false });
-
-// Override the default back behavior
-element.addEventListener('cap-swipe-back', (event) => {
-  event.preventDefault();
-  router.back();
-});
+setupRouterOutlet(element, { swipeGesture: true });
+setupRouterOutlet(element, { swipeGesture: false });
 
 // Set up a page element with lifecycle callbacks (returns cleanup function)
 setupPage(element, { onWillEnter, onDidEnter, onWillLeave, onDidLeave });

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Framework-agnostic page transitions for Capacitor apps. iOS-style navigation wit
 - **No Design Opinions** - Just transition logic, you bring your own styles
 - **Coordinated Transitions** - Header, content, and footer animate together
 - **Page Caching** - Keep pages in DOM for instant back navigation
+- **Native iOS Swipe Back** - Optional edge-swipe back gesture with Capacitor native runtime detection
 - **Lifecycle Hooks** - willEnter, didEnter, willLeave, didLeave events
 
 ## Compatibility
@@ -76,7 +77,7 @@ function App() {
 
   useEffect(() => {
     if (outletRef.current) {
-      setupRouterOutlet(outletRef.current, { platform: 'auto' });
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeBack: 'auto' });
     }
   }, []);
 
@@ -290,18 +291,26 @@ export class HomeComponent {
 
 Container for page transitions.
 
-| Attribute     | Type                           | Default          | Description                             |
-| ------------- | ------------------------------ | ---------------- | --------------------------------------- |
-| `platform`    | `'ios' \| 'android' \| 'auto'` | `'auto'`         | Animation style                         |
-| `duration`    | `number`                       | Platform default | Animation duration in ms                |
-| `keep-in-dom` | `boolean`                      | `true`           | Keep pages in DOM after navigating away |
-| `max-cached`  | `number`                       | `10`             | Maximum pages to keep cached            |
+| Attribute     | Type                           | Default          | Description                                                                |
+| ------------- | ------------------------------ | ---------------- | -------------------------------------------------------------------------- |
+| `platform`    | `'ios' \| 'android' \| 'auto'` | `'auto'`         | Animation style                                                            |
+| `duration`    | `number`                       | Platform default | Animation duration in ms                                                   |
+| `keep-in-dom` | `boolean`                      | `true`           | Keep pages in DOM after navigating away                                    |
+| `max-cached`  | `number`                       | `10`             | Maximum pages to keep cached                                               |
+| `swipe-back`  | `boolean \| 'auto'`            | `'auto'`         | Enable edge swipe-back. `'auto'` enables only in native iOS Capacitor apps |
 
 Methods:
 
 - `push(element, config?)` - Navigate forward to new page
 - `pop(config?)` - Navigate back
 - `setRoot(element, config?)` - Replace navigation stack
+- `setSwipeBack(true | false | 'auto')` - Enable, disable, or native-detect edge swipe-back
+
+Events:
+
+- `cap-swipe-back` - Fired when an edge swipe-back gesture commits. The event is cancelable; call `event.preventDefault()` and perform your own router back action to override the default `window.history.back()` fallback.
+
+`swipe-back="auto"` uses Capacitor's runtime helpers (`Capacitor.isNativePlatform()` and `Capacitor.getPlatform()`) and enables the gesture only for native iOS apps. Use `swipe-back="true"` to force it on any platform or `swipe-back="false"` to disable it.
 
 #### `<cap-page>`
 
@@ -354,6 +363,19 @@ setDirection('forward' | 'back' | 'root' | 'none');
 
 // Set up a router outlet element
 setupRouterOutlet(element, options);
+
+// Enable native-detected iOS edge swipe-back (default)
+setupRouterOutlet(element, { swipeBack: 'auto' });
+
+// Force enable or disable from JavaScript
+setupRouterOutlet(element, { swipeBack: true });
+setupRouterOutlet(element, { swipeBack: false });
+
+// Override the default back behavior
+element.addEventListener('cap-swipe-back', (event) => {
+  event.preventDefault();
+  router.back();
+});
 
 // Set up a page element with lifecycle callbacks (returns cleanup function)
 setupPage(element, { onWillEnter, onDidEnter, onWillLeave, onDidLeave });

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -175,7 +175,7 @@ function App() {
 
   useEffect(() => {
     if (outletRef.current) {
-      setupRouterOutlet(outletRef.current, { platform: 'auto' })
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeBack: 'auto' })
     }
   }, [])
 

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -175,7 +175,7 @@ function App() {
 
   useEffect(() => {
     if (outletRef.current) {
-      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeBack: 'auto' })
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeGesture: 'auto' })
     }
   }, [])
 

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -4,7 +4,7 @@
  * Works with any framework's router
  */
 
-import { detectNativePlatform, isNativeBackSwipePlatform } from '../core/native-platform';
+import { isNativeSwipeGesturePlatform } from '../core/native-platform';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
 import type {
@@ -12,8 +12,7 @@ import type {
   TransitionGlobalConfig,
   TransitionDirection,
   PageState,
-  SwipeBackOption,
-  SwipeBackEventDetail,
+  SwipeGestureOption,
 } from '../core/types';
 
 export interface CapRouterOutletOptions extends TransitionGlobalConfig {
@@ -22,10 +21,10 @@ export interface CapRouterOutletOptions extends TransitionGlobalConfig {
   /** Maximum cached pages */
   maxCached?: number;
   /** Edge swipe-back gesture support */
-  swipeBack?: SwipeBackOption;
+  swipeGesture?: SwipeGestureOption;
 }
 
-interface SwipeBackPointerState {
+interface SwipeGesturePointerState {
   pointerId: number;
   startX: number;
   startY: number;
@@ -33,6 +32,7 @@ interface SwipeBackPointerState {
   currentY: number;
   startTime: number;
   dragging: boolean;
+  transitionStarted: boolean;
 }
 
 /**
@@ -45,15 +45,16 @@ export class CapRouterOutlet extends HTMLElement {
   private observer: MutationObserver | null = null;
   private pendingPage: HTMLElement | null = null;
   private ignoredNodes = new WeakSet<HTMLElement>();
-  private swipeBackPointer: SwipeBackPointerState | null = null;
-  private swipeBackListenersActive = false;
+  private swipeGesturePointer: SwipeGesturePointerState | null = null;
+  private swipeGestureListenersActive = false;
+  private skipNextHistoryBackTransition = false;
 
-  private readonly swipeBackEdgeWidth = 32;
-  private readonly swipeBackMinimumDistance = 72;
-  private readonly swipeBackMinimumVelocity = 0.45;
+  private readonly swipeGestureEdgeWidth = 50;
+  private readonly swipeGestureThreshold = 10;
+  private readonly swipeGestureMinimumVelocity = 0.2;
 
   static get observedAttributes(): string[] {
-    return ['platform', 'duration', 'keep-in-dom', 'max-cached', 'swipe-back'];
+    return ['platform', 'duration', 'keep-in-dom', 'max-cached', 'swipe-gesture'];
   }
 
   constructor() {
@@ -62,7 +63,7 @@ export class CapRouterOutlet extends HTMLElement {
     this.options = {
       keepInDom: true,
       maxCached: 10,
-      swipeBack: 'auto',
+      swipeGesture: 'auto',
     };
 
     this.controller = createTransitionController();
@@ -92,12 +93,12 @@ export class CapRouterOutlet extends HTMLElement {
       this.initializeFirstPage(children[children.length - 1]);
     }
 
-    this.updateSwipeBackListeners();
+    this.updateSwipeGestureListeners();
   }
 
   disconnectedCallback(): void {
     this.observer?.disconnect();
-    this.removeSwipeBackListeners();
+    this.removeSwipeGestureListeners();
     this.controller.clear();
   }
 
@@ -115,9 +116,9 @@ export class CapRouterOutlet extends HTMLElement {
       case 'max-cached':
         this.options.maxCached = parseInt(newValue, 10);
         break;
-      case 'swipe-back':
-        this.options.swipeBack = this.parseSwipeBackAttribute(newValue);
-        this.updateSwipeBackListeners();
+      case 'swipe-gesture':
+        this.options.swipeGesture = this.parseSwipeGestureAttribute(newValue);
+        this.updateSwipeGestureListeners();
         break;
     }
   }
@@ -207,6 +208,8 @@ export class CapRouterOutlet extends HTMLElement {
     if (outletDirection) {
       delete this.dataset.direction;
     }
+    const skipTransition = this.skipNextHistoryBackTransition && direction === 'back';
+    this.skipNextHistoryBackTransition = false;
 
     // Set up the page element
     this.stylePageForTransition(page);
@@ -214,7 +217,7 @@ export class CapRouterOutlet extends HTMLElement {
     this.pendingPage = page;
 
     try {
-      await this.controller.navigate(page, { direction });
+      await this.controller.navigate(page, { direction, duration: skipTransition ? 0 : undefined });
     } finally {
       this.pendingPage = null;
     }
@@ -319,30 +322,30 @@ export class CapRouterOutlet extends HTMLElement {
   }
 
   /**
-   * Get whether edge swipe-back is enabled.
+   * Get whether edge swipe-back gesture is enabled.
    */
-  get swipeBack(): SwipeBackOption {
-    return this.options.swipeBack ?? 'auto';
+  get swipeGesture(): SwipeGestureOption {
+    return this.options.swipeGesture ?? 'auto';
   }
 
   /**
-   * Enable, disable, or native-detect edge swipe-back.
+   * Enable, disable, or auto-detect edge swipe-back gesture.
    */
-  set swipeBack(value: SwipeBackOption) {
-    this.setSwipeBack(value);
+  set swipeGesture(value: SwipeGestureOption) {
+    this.setSwipeGesture(value);
   }
 
   /**
-   * Enable, disable, or native-detect edge swipe-back.
+   * Enable, disable, or auto-detect edge swipe-back gesture.
    */
-  setSwipeBack(value: SwipeBackOption): void {
-    this.options.swipeBack = value;
+  setSwipeGesture(value: SwipeGestureOption): void {
+    this.options.swipeGesture = value;
 
-    const serialized = this.serializeSwipeBack(value);
-    if (this.getAttribute('swipe-back') !== serialized) {
-      this.setAttribute('swipe-back', serialized);
+    const serialized = this.serializeSwipeGesture(value);
+    if (this.getAttribute('swipe-gesture') !== serialized) {
+      this.setAttribute('swipe-gesture', serialized);
     } else {
-      this.updateSwipeBackListeners();
+      this.updateSwipeGestureListeners();
     }
   }
 
@@ -364,7 +367,7 @@ export class CapRouterOutlet extends HTMLElement {
     page.style.height = '100%';
   }
 
-  private parseSwipeBackAttribute(value: string | null): SwipeBackOption {
+  private parseSwipeGestureAttribute(value: string | null): SwipeGestureOption {
     if (value === null || value === 'auto') {
       return 'auto';
     }
@@ -376,42 +379,42 @@ export class CapRouterOutlet extends HTMLElement {
     return true;
   }
 
-  private serializeSwipeBack(value: SwipeBackOption): string {
+  private serializeSwipeGesture(value: SwipeGestureOption): string {
     return typeof value === 'boolean' ? String(value) : value;
   }
 
-  private updateSwipeBackListeners(): void {
-    if (this.options.swipeBack === false) {
-      this.removeSwipeBackListeners();
+  private updateSwipeGestureListeners(): void {
+    if (this.options.swipeGesture === false) {
+      this.removeSwipeGestureListeners();
       return;
     }
 
-    if (this.swipeBackListenersActive || typeof PointerEvent === 'undefined') {
+    if (this.swipeGestureListenersActive || typeof PointerEvent === 'undefined') {
       return;
     }
 
-    this.addEventListener('pointerdown', this.handleSwipeBackPointerDown);
-    this.addEventListener('pointermove', this.handleSwipeBackPointerMove, { passive: false });
-    this.addEventListener('pointerup', this.handleSwipeBackPointerEnd);
-    this.addEventListener('pointercancel', this.handleSwipeBackPointerCancel);
-    this.swipeBackListenersActive = true;
+    this.addEventListener('pointerdown', this.handleSwipeGesturePointerDown);
+    this.addEventListener('pointermove', this.handleSwipeGesturePointerMove, { passive: false });
+    this.addEventListener('pointerup', this.handleSwipeGesturePointerEnd);
+    this.addEventListener('pointercancel', this.handleSwipeGesturePointerCancel);
+    this.swipeGestureListenersActive = true;
   }
 
-  private removeSwipeBackListeners(): void {
-    if (!this.swipeBackListenersActive) {
+  private removeSwipeGestureListeners(): void {
+    if (!this.swipeGestureListenersActive) {
       return;
     }
 
-    this.removeEventListener('pointerdown', this.handleSwipeBackPointerDown);
-    this.removeEventListener('pointermove', this.handleSwipeBackPointerMove);
-    this.removeEventListener('pointerup', this.handleSwipeBackPointerEnd);
-    this.removeEventListener('pointercancel', this.handleSwipeBackPointerCancel);
-    this.swipeBackListenersActive = false;
-    this.swipeBackPointer = null;
+    this.removeEventListener('pointerdown', this.handleSwipeGesturePointerDown);
+    this.removeEventListener('pointermove', this.handleSwipeGesturePointerMove);
+    this.removeEventListener('pointerup', this.handleSwipeGesturePointerEnd);
+    this.removeEventListener('pointercancel', this.handleSwipeGesturePointerCancel);
+    this.swipeGestureListenersActive = false;
+    this.swipeGesturePointer = null;
   }
 
-  private isSwipeBackEnabled(): boolean {
-    const option = this.options.swipeBack ?? 'auto';
+  private isSwipeGestureEnabled(): boolean {
+    const option = this.options.swipeGesture ?? 'auto';
 
     if (option === true) {
       return true;
@@ -421,11 +424,11 @@ export class CapRouterOutlet extends HTMLElement {
       return false;
     }
 
-    return isNativeBackSwipePlatform();
+    return isNativeSwipeGesturePlatform();
   }
 
-  private canStartSwipeBack(event: PointerEvent): boolean {
-    if (!this.isSwipeBackEnabled() || this.controller.animating || this.pendingPage || !this.canGoBack) {
+  private canStartSwipeGesture(event: PointerEvent): boolean {
+    if (!this.isSwipeGestureEnabled() || this.controller.animating || this.pendingPage || !this.canGoBack) {
       return false;
     }
 
@@ -440,9 +443,21 @@ export class CapRouterOutlet extends HTMLElement {
     const rect = this.getBoundingClientRect();
     const startX = event.clientX - rect.left;
 
-    return (
-      startX >= 0 && startX <= this.swipeBackEdgeWidth && event.clientY >= rect.top && event.clientY <= rect.bottom
-    );
+    if (event.clientY < rect.top || event.clientY > rect.bottom) {
+      return false;
+    }
+
+    return this.isRTL() ? startX >= rect.width - this.swipeGestureEdgeWidth : startX <= this.swipeGestureEdgeWidth;
+  }
+
+  private isRTL(): boolean {
+    const doc = this.ownerDocument;
+    return doc.dir === 'rtl' || doc.documentElement.dir === 'rtl' || getComputedStyle(this).direction === 'rtl';
+  }
+
+  private getSwipeGestureDeltaX(pointer: SwipeGesturePointerState): number {
+    const deltaX = pointer.currentX - pointer.startX;
+    return this.isRTL() ? -deltaX : deltaX;
   }
 
   private isInteractiveSwipeTarget(target: EventTarget | null): boolean {
@@ -451,7 +466,9 @@ export class CapRouterOutlet extends HTMLElement {
     }
 
     return Boolean(
-      target.closest('a, button, input, textarea, select, option, [contenteditable="true"], [data-swipe-back-ignore]'),
+      target.closest(
+        'a, button, input, textarea, select, option, [contenteditable="true"], [data-swipe-gesture-ignore], [data-swipe-back-ignore]',
+      ),
     );
   }
 
@@ -474,12 +491,12 @@ export class CapRouterOutlet extends HTMLElement {
     return false;
   }
 
-  private handleSwipeBackPointerDown = (event: PointerEvent): void => {
-    if (!this.canStartSwipeBack(event)) {
+  private handleSwipeGesturePointerDown = (event: PointerEvent): void => {
+    if (!this.canStartSwipeGesture(event)) {
       return;
     }
 
-    this.swipeBackPointer = {
+    this.swipeGesturePointer = {
       pointerId: event.pointerId,
       startX: event.clientX,
       startY: event.clientY,
@@ -487,6 +504,7 @@ export class CapRouterOutlet extends HTMLElement {
       currentY: event.clientY,
       startTime: performance.now(),
       dragging: false,
+      transitionStarted: false,
     };
 
     try {
@@ -496,8 +514,8 @@ export class CapRouterOutlet extends HTMLElement {
     }
   };
 
-  private handleSwipeBackPointerMove = (event: PointerEvent): void => {
-    const pointer = this.swipeBackPointer;
+  private handleSwipeGesturePointerMove = (event: PointerEvent): void => {
+    const pointer = this.swipeGesturePointer;
     if (!pointer || pointer.pointerId !== event.pointerId) {
       return;
     }
@@ -505,31 +523,40 @@ export class CapRouterOutlet extends HTMLElement {
     pointer.currentX = event.clientX;
     pointer.currentY = event.clientY;
 
-    const deltaX = pointer.currentX - pointer.startX;
+    const deltaX = this.getSwipeGestureDeltaX(pointer);
     const deltaY = pointer.currentY - pointer.startY;
     const absX = Math.abs(deltaX);
     const absY = Math.abs(deltaY);
 
     if (!pointer.dragging && absY > 12 && absY > absX) {
-      this.cancelSwipeBackPointer(event.pointerId);
+      this.cancelSwipeGesturePointer(event.pointerId);
       return;
     }
 
-    if (deltaX < -8) {
-      this.cancelSwipeBackPointer(event.pointerId);
+    if (deltaX < -this.swipeGestureThreshold) {
+      this.cancelSwipeGesture(event.pointerId);
       return;
     }
 
-    if (deltaX > 8 && absX > absY) {
+    if (!pointer.dragging && deltaX > this.swipeGestureThreshold && absX > absY) {
       pointer.dragging = true;
-      if (event.cancelable) {
-        event.preventDefault();
+      pointer.transitionStarted = this.controller.beginInteractiveBack({ direction: 'back' });
+
+      if (!pointer.transitionStarted) {
+        this.cancelSwipeGesturePointer(event.pointerId);
+        return;
       }
+    }
+
+    if (pointer.dragging && pointer.transitionStarted) {
+      if (event.cancelable) event.preventDefault();
+      const width = Math.max(this.getBoundingClientRect().width, 1);
+      this.controller.stepInteractiveBack(deltaX / width);
     }
   };
 
-  private handleSwipeBackPointerEnd = (event: PointerEvent): void => {
-    const pointer = this.swipeBackPointer;
+  private handleSwipeGesturePointerEnd = (event: PointerEvent): void => {
+    const pointer = this.swipeGesturePointer;
     if (!pointer || pointer.pointerId !== event.pointerId) {
       return;
     }
@@ -537,30 +564,36 @@ export class CapRouterOutlet extends HTMLElement {
     pointer.currentX = event.clientX;
     pointer.currentY = event.clientY;
 
-    const deltaX = pointer.currentX - pointer.startX;
-    const deltaY = pointer.currentY - pointer.startY;
+    const deltaX = this.getSwipeGestureDeltaX(pointer);
     const elapsed = Math.max(performance.now() - pointer.startTime, 1);
     const velocityX = deltaX / elapsed;
-    const minDistance = Math.min(this.swipeBackMinimumDistance, this.clientWidth * 0.35);
-    const verticalAllowed = Math.abs(deltaY) <= Math.max(80, Math.abs(deltaX) * 0.8);
+    const width = Math.max(this.getBoundingClientRect().width, 1);
+    const step = deltaX / width;
     const shouldCommit =
-      verticalAllowed &&
-      deltaX > 0 &&
-      (deltaX >= minDistance || (deltaX >= 40 && velocityX >= this.swipeBackMinimumVelocity));
+      pointer.dragging &&
+      pointer.transitionStarted &&
+      velocityX >= 0 &&
+      (velocityX > this.swipeGestureMinimumVelocity || deltaX > width / 2);
+    const missing = shouldCommit ? 1 - step : step;
+    const missingDistance = Math.max(missing, 0) * width;
+    const releaseDuration =
+      missingDistance > 5 && Math.abs(velocityX) > 0 ? Math.min(missingDistance / Math.abs(velocityX), 540) : 0;
 
-    this.cancelSwipeBackPointer(event.pointerId);
+    this.releaseSwipeGesturePointer(event.pointerId);
 
-    if (shouldCommit) {
-      this.commitSwipeBack(deltaX, deltaY, velocityX);
-    }
+    void this.finishSwipeGestureBack(shouldCommit, releaseDuration);
   };
 
-  private handleSwipeBackPointerCancel = (event: PointerEvent): void => {
-    this.cancelSwipeBackPointer(event.pointerId);
+  private handleSwipeGesturePointerCancel = (event: PointerEvent): void => {
+    this.cancelSwipeGesture(event.pointerId);
   };
 
-  private cancelSwipeBackPointer(pointerId: number): void {
-    if (this.swipeBackPointer?.pointerId !== pointerId) {
+  private cancelSwipeGesturePointer(pointerId: number): void {
+    this.releaseSwipeGesturePointer(pointerId);
+  }
+
+  private releaseSwipeGesturePointer(pointerId: number): void {
+    if (this.swipeGesturePointer?.pointerId !== pointerId) {
       return;
     }
 
@@ -570,38 +603,41 @@ export class CapRouterOutlet extends HTMLElement {
       // Ignore missing pointer capture.
     }
 
-    this.swipeBackPointer = null;
+    this.swipeGesturePointer = null;
   }
 
-  private commitSwipeBack(deltaX: number, deltaY: number, velocityX: number): void {
-    const platform = detectNativePlatform();
-    const detail: SwipeBackEventDetail = {
-      direction: 'back',
-      platform: platform.platform,
-      native: platform.isNative,
-      deltaX,
-      deltaY,
-      velocityX,
-    };
-    const event = new CustomEvent<SwipeBackEventDetail>('cap-swipe-back', {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      detail,
-    });
-
-    if (!this.dispatchEvent(event)) {
+  private cancelSwipeGesture(pointerId: number): void {
+    const pointer = this.swipeGesturePointer;
+    if (!pointer || pointer.pointerId !== pointerId) {
       return;
     }
 
-    this.dataset.direction = 'back';
+    this.releaseSwipeGesturePointer(pointerId);
 
-    if (typeof window !== 'undefined' && window.history.length > 1) {
+    if (pointer.transitionStarted) {
+      void this.finishSwipeGestureBack(false, 0);
+    }
+  }
+
+  private async finishSwipeGestureBack(shouldComplete: boolean, releaseDuration: number): Promise<void> {
+    const shouldUseHistory = shouldComplete && typeof window !== 'undefined' && window.history.length > 1;
+
+    await this.controller.endInteractiveBack(shouldComplete, releaseDuration, !shouldUseHistory);
+
+    if (!shouldComplete) {
+      return;
+    }
+
+    if (shouldUseHistory) {
+      this.skipNextHistoryBackTransition = true;
+      this.dataset.direction = 'back';
       window.history.back();
       return;
     }
 
-    void this.pop({ direction: 'back' });
+    if (!this.options.keepInDom) {
+      this.cleanupOldPages();
+    }
   }
 }
 

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -4,15 +4,35 @@
  * Works with any framework's router
  */
 
+import { detectNativePlatform, isNativeBackSwipePlatform } from '../core/native-platform';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionConfig, TransitionGlobalConfig, TransitionDirection, PageState } from '../core/types';
+import type {
+  TransitionConfig,
+  TransitionGlobalConfig,
+  TransitionDirection,
+  PageState,
+  SwipeBackOption,
+  SwipeBackEventDetail,
+} from '../core/types';
 
 export interface CapRouterOutletOptions extends TransitionGlobalConfig {
   /** Keep pages in DOM after navigating away */
   keepInDom?: boolean;
   /** Maximum cached pages */
   maxCached?: number;
+  /** Edge swipe-back gesture support */
+  swipeBack?: SwipeBackOption;
+}
+
+interface SwipeBackPointerState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+  startTime: number;
+  dragging: boolean;
 }
 
 /**
@@ -25,9 +45,15 @@ export class CapRouterOutlet extends HTMLElement {
   private observer: MutationObserver | null = null;
   private pendingPage: HTMLElement | null = null;
   private ignoredNodes = new WeakSet<HTMLElement>();
+  private swipeBackPointer: SwipeBackPointerState | null = null;
+  private swipeBackListenersActive = false;
+
+  private readonly swipeBackEdgeWidth = 32;
+  private readonly swipeBackMinimumDistance = 72;
+  private readonly swipeBackMinimumVelocity = 0.45;
 
   static get observedAttributes(): string[] {
-    return ['platform', 'duration', 'keep-in-dom', 'max-cached'];
+    return ['platform', 'duration', 'keep-in-dom', 'max-cached', 'swipe-back'];
   }
 
   constructor() {
@@ -36,6 +62,7 @@ export class CapRouterOutlet extends HTMLElement {
     this.options = {
       keepInDom: true,
       maxCached: 10,
+      swipeBack: 'auto',
     };
 
     this.controller = createTransitionController();
@@ -64,10 +91,13 @@ export class CapRouterOutlet extends HTMLElement {
     if (children.length > 0) {
       this.initializeFirstPage(children[children.length - 1]);
     }
+
+    this.updateSwipeBackListeners();
   }
 
   disconnectedCallback(): void {
     this.observer?.disconnect();
+    this.removeSwipeBackListeners();
     this.controller.clear();
   }
 
@@ -84,6 +114,10 @@ export class CapRouterOutlet extends HTMLElement {
         break;
       case 'max-cached':
         this.options.maxCached = parseInt(newValue, 10);
+        break;
+      case 'swipe-back':
+        this.options.swipeBack = this.parseSwipeBackAttribute(newValue);
+        this.updateSwipeBackListeners();
         break;
     }
   }
@@ -285,6 +319,34 @@ export class CapRouterOutlet extends HTMLElement {
   }
 
   /**
+   * Get whether edge swipe-back is enabled.
+   */
+  get swipeBack(): SwipeBackOption {
+    return this.options.swipeBack ?? 'auto';
+  }
+
+  /**
+   * Enable, disable, or native-detect edge swipe-back.
+   */
+  set swipeBack(value: SwipeBackOption) {
+    this.setSwipeBack(value);
+  }
+
+  /**
+   * Enable, disable, or native-detect edge swipe-back.
+   */
+  setSwipeBack(value: SwipeBackOption): void {
+    this.options.swipeBack = value;
+
+    const serialized = this.serializeSwipeBack(value);
+    if (this.getAttribute('swipe-back') !== serialized) {
+      this.setAttribute('swipe-back', serialized);
+    } else {
+      this.updateSwipeBackListeners();
+    }
+  }
+
+  /**
    * Get the transition controller for advanced usage
    */
   getController(): TransitionController {
@@ -300,6 +362,246 @@ export class CapRouterOutlet extends HTMLElement {
     page.style.left = '0';
     page.style.width = '100%';
     page.style.height = '100%';
+  }
+
+  private parseSwipeBackAttribute(value: string | null): SwipeBackOption {
+    if (value === null || value === 'auto') {
+      return 'auto';
+    }
+
+    if (value === 'false') {
+      return false;
+    }
+
+    return true;
+  }
+
+  private serializeSwipeBack(value: SwipeBackOption): string {
+    return typeof value === 'boolean' ? String(value) : value;
+  }
+
+  private updateSwipeBackListeners(): void {
+    if (this.options.swipeBack === false) {
+      this.removeSwipeBackListeners();
+      return;
+    }
+
+    if (this.swipeBackListenersActive || typeof PointerEvent === 'undefined') {
+      return;
+    }
+
+    this.addEventListener('pointerdown', this.handleSwipeBackPointerDown);
+    this.addEventListener('pointermove', this.handleSwipeBackPointerMove, { passive: false });
+    this.addEventListener('pointerup', this.handleSwipeBackPointerEnd);
+    this.addEventListener('pointercancel', this.handleSwipeBackPointerCancel);
+    this.swipeBackListenersActive = true;
+  }
+
+  private removeSwipeBackListeners(): void {
+    if (!this.swipeBackListenersActive) {
+      return;
+    }
+
+    this.removeEventListener('pointerdown', this.handleSwipeBackPointerDown);
+    this.removeEventListener('pointermove', this.handleSwipeBackPointerMove);
+    this.removeEventListener('pointerup', this.handleSwipeBackPointerEnd);
+    this.removeEventListener('pointercancel', this.handleSwipeBackPointerCancel);
+    this.swipeBackListenersActive = false;
+    this.swipeBackPointer = null;
+  }
+
+  private isSwipeBackEnabled(): boolean {
+    const option = this.options.swipeBack ?? 'auto';
+
+    if (option === true) {
+      return true;
+    }
+
+    if (option === false) {
+      return false;
+    }
+
+    return isNativeBackSwipePlatform();
+  }
+
+  private canStartSwipeBack(event: PointerEvent): boolean {
+    if (!this.isSwipeBackEnabled() || this.controller.animating || this.pendingPage || !this.canGoBack) {
+      return false;
+    }
+
+    if (!event.isPrimary || (event.pointerType === 'mouse' && event.button !== 0)) {
+      return false;
+    }
+
+    if (this.isInteractiveSwipeTarget(event.target) || this.hasScrollableInlineAncestor(event.target)) {
+      return false;
+    }
+
+    const rect = this.getBoundingClientRect();
+    const startX = event.clientX - rect.left;
+
+    return (
+      startX >= 0 && startX <= this.swipeBackEdgeWidth && event.clientY >= rect.top && event.clientY <= rect.bottom
+    );
+  }
+
+  private isInteractiveSwipeTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+
+    return Boolean(
+      target.closest('a, button, input, textarea, select, option, [contenteditable="true"], [data-swipe-back-ignore]'),
+    );
+  }
+
+  private hasScrollableInlineAncestor(target: EventTarget | null): boolean {
+    let element = target instanceof Element ? target : null;
+
+    while (element && element !== this) {
+      if (element instanceof HTMLElement) {
+        const style = getComputedStyle(element);
+        const canScrollInline = /(auto|scroll)/.test(style.overflowX) && element.scrollWidth > element.clientWidth + 1;
+
+        if (canScrollInline && element.scrollLeft > 0) {
+          return true;
+        }
+      }
+
+      element = element.parentElement;
+    }
+
+    return false;
+  }
+
+  private handleSwipeBackPointerDown = (event: PointerEvent): void => {
+    if (!this.canStartSwipeBack(event)) {
+      return;
+    }
+
+    this.swipeBackPointer = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      currentX: event.clientX,
+      currentY: event.clientY,
+      startTime: performance.now(),
+      dragging: false,
+    };
+
+    try {
+      this.setPointerCapture(event.pointerId);
+    } catch {
+      // Some WebViews can throw if capture is unavailable for this pointer.
+    }
+  };
+
+  private handleSwipeBackPointerMove = (event: PointerEvent): void => {
+    const pointer = this.swipeBackPointer;
+    if (!pointer || pointer.pointerId !== event.pointerId) {
+      return;
+    }
+
+    pointer.currentX = event.clientX;
+    pointer.currentY = event.clientY;
+
+    const deltaX = pointer.currentX - pointer.startX;
+    const deltaY = pointer.currentY - pointer.startY;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (!pointer.dragging && absY > 12 && absY > absX) {
+      this.cancelSwipeBackPointer(event.pointerId);
+      return;
+    }
+
+    if (deltaX < -8) {
+      this.cancelSwipeBackPointer(event.pointerId);
+      return;
+    }
+
+    if (deltaX > 8 && absX > absY) {
+      pointer.dragging = true;
+      if (event.cancelable) {
+        event.preventDefault();
+      }
+    }
+  };
+
+  private handleSwipeBackPointerEnd = (event: PointerEvent): void => {
+    const pointer = this.swipeBackPointer;
+    if (!pointer || pointer.pointerId !== event.pointerId) {
+      return;
+    }
+
+    pointer.currentX = event.clientX;
+    pointer.currentY = event.clientY;
+
+    const deltaX = pointer.currentX - pointer.startX;
+    const deltaY = pointer.currentY - pointer.startY;
+    const elapsed = Math.max(performance.now() - pointer.startTime, 1);
+    const velocityX = deltaX / elapsed;
+    const minDistance = Math.min(this.swipeBackMinimumDistance, this.clientWidth * 0.35);
+    const verticalAllowed = Math.abs(deltaY) <= Math.max(80, Math.abs(deltaX) * 0.8);
+    const shouldCommit =
+      verticalAllowed &&
+      deltaX > 0 &&
+      (deltaX >= minDistance || (deltaX >= 40 && velocityX >= this.swipeBackMinimumVelocity));
+
+    this.cancelSwipeBackPointer(event.pointerId);
+
+    if (shouldCommit) {
+      this.commitSwipeBack(deltaX, deltaY, velocityX);
+    }
+  };
+
+  private handleSwipeBackPointerCancel = (event: PointerEvent): void => {
+    this.cancelSwipeBackPointer(event.pointerId);
+  };
+
+  private cancelSwipeBackPointer(pointerId: number): void {
+    if (this.swipeBackPointer?.pointerId !== pointerId) {
+      return;
+    }
+
+    try {
+      this.releasePointerCapture(pointerId);
+    } catch {
+      // Ignore missing pointer capture.
+    }
+
+    this.swipeBackPointer = null;
+  }
+
+  private commitSwipeBack(deltaX: number, deltaY: number, velocityX: number): void {
+    const platform = detectNativePlatform();
+    const detail: SwipeBackEventDetail = {
+      direction: 'back',
+      platform: platform.platform,
+      native: platform.isNative,
+      deltaX,
+      deltaY,
+      velocityX,
+    };
+    const event = new CustomEvent<SwipeBackEventDetail>('cap-swipe-back', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      detail,
+    });
+
+    if (!this.dispatchEvent(event)) {
+      return;
+    }
+
+    this.dataset.direction = 'back';
+
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    void this.pop({ direction: 'back' });
   }
 }
 

--- a/src/core/native-platform.ts
+++ b/src/core/native-platform.ts
@@ -1,0 +1,35 @@
+import type { NativePlatform, NativePlatformInfo } from './types';
+
+interface CapacitorRuntime {
+  getPlatform?: () => string;
+  isNativePlatform?: () => boolean;
+}
+
+function getCapacitorRuntime(): CapacitorRuntime | undefined {
+  return (globalThis as { Capacitor?: CapacitorRuntime }).Capacitor;
+}
+
+function normalizePlatform(platform: string | undefined): NativePlatform {
+  if (platform === 'ios' || platform === 'android' || platform === 'web') {
+    return platform;
+  }
+
+  return 'unknown';
+}
+
+export function detectNativePlatform(): NativePlatformInfo {
+  const capacitor = getCapacitorRuntime();
+  const platform = normalizePlatform(capacitor?.getPlatform?.());
+  const isNative = capacitor?.isNativePlatform?.() ?? (platform === 'ios' || platform === 'android');
+
+  return {
+    platform,
+    isNative,
+  };
+}
+
+export function isNativeBackSwipePlatform(): boolean {
+  const { platform, isNative } = detectNativePlatform();
+
+  return isNative && platform === 'ios';
+}

--- a/src/core/native-platform.ts
+++ b/src/core/native-platform.ts
@@ -28,7 +28,7 @@ export function detectNativePlatform(): NativePlatformInfo {
   };
 }
 
-export function isNativeBackSwipePlatform(): boolean {
+export function isNativeSwipeGesturePlatform(): boolean {
   const { platform, isNative } = detectNativePlatform();
 
   return isNative && platform === 'ios';

--- a/src/core/transition-controller.ts
+++ b/src/core/transition-controller.ts
@@ -38,6 +38,13 @@ const DEFAULT_CONFIG: Required<TransitionGlobalConfig> = {
   detectPlatform,
 };
 
+interface InteractiveBackTransition {
+  enteringState: PageState;
+  leavingState: PageState;
+  animations: Animation[];
+  duration: number;
+}
+
 /**
  * Transition Controller
  * Central manager for all page transitions
@@ -47,6 +54,7 @@ export class TransitionController {
   private pageStack: PageState[] = [];
   private currentAnimations: Animation[] = [];
   private isAnimating = false;
+  private interactiveBackTransition: InteractiveBackTransition | null = null;
   private lifecycleCallbacks: Map<string, TransitionLifecycle> = new Map();
 
   constructor(config: TransitionGlobalConfig = {}) {
@@ -169,6 +177,113 @@ export class TransitionController {
   }
 
   /**
+   * Start an interactive iOS-style back transition using the cached previous page.
+   */
+  beginInteractiveBack(config: TransitionConfig = {}): boolean {
+    if (this.pageStack.length <= 1 || this.isAnimating || this.interactiveBackTransition) {
+      return false;
+    }
+
+    const leavingState = this.pageStack[this.pageStack.length - 1];
+    const enteringState = this.pageStack[this.pageStack.length - 2];
+    const direction = 'back';
+    const duration = config.duration ?? (this.config.duration || getDefaultDuration(this.platform, direction));
+
+    this.isAnimating = true;
+    enteringState.element.style.display = '';
+    enteringState.element.style.visibility = 'visible';
+
+    const animOptions: TransitionAnimationOptions = {
+      enteringEl: enteringState.element,
+      leavingEl: leavingState.element,
+      direction,
+      duration,
+      easing: 'linear',
+      isBack: true,
+    };
+
+    const animations = createTransition(animOptions, this.platform);
+    for (const animation of animations) {
+      animation.pause();
+      animation.currentTime = 0;
+    }
+
+    this.currentAnimations = animations;
+    this.interactiveBackTransition = {
+      enteringState,
+      leavingState,
+      animations,
+      duration,
+    };
+
+    return true;
+  }
+
+  /**
+   * Move the current interactive back transition to a progress step from 0 to 1.
+   */
+  stepInteractiveBack(step: number): void {
+    const transition = this.interactiveBackTransition;
+    if (!transition) {
+      return;
+    }
+
+    const progress = Math.max(0, Math.min(step, 0.9999));
+    for (const animation of transition.animations) {
+      const duration = this.getAnimationDuration(animation, transition.duration);
+      animation.pause();
+      animation.currentTime = duration * progress;
+    }
+  }
+
+  /**
+   * Complete or cancel the current interactive back transition.
+   */
+  async endInteractiveBack(shouldComplete: boolean, releaseDuration: number, commitStack: boolean): Promise<void> {
+    const transition = this.interactiveBackTransition;
+    if (!transition) {
+      return;
+    }
+
+    try {
+      await this.playInteractiveAnimationsTo(shouldComplete ? 1 : 0, releaseDuration);
+
+      if (shouldComplete && commitStack) {
+        this.pageStack.pop();
+        this.updatePageVisibility(transition.enteringState, transition.leavingState);
+        transition.enteringState.isActive = true;
+        transition.leavingState.isActive = false;
+        cancelAnimations(transition.animations);
+      } else if (!shouldComplete) {
+        this.updatePageVisibility(transition.leavingState, transition.enteringState);
+        transition.leavingState.isActive = true;
+        transition.enteringState.isActive = false;
+        cancelAnimations(transition.animations);
+      }
+    } finally {
+      this.interactiveBackTransition = null;
+      this.currentAnimations = [];
+      this.isAnimating = false;
+    }
+  }
+
+  /**
+   * Cancel the current interactive back transition immediately.
+   */
+  cancelInteractiveBack(): void {
+    const transition = this.interactiveBackTransition;
+    if (!transition) {
+      return;
+    }
+
+    cancelAnimations(transition.animations);
+    this.updatePageVisibility(transition.leavingState, transition.enteringState);
+    this.interactiveBackTransition = null;
+    this.currentAnimations = [];
+    this.isAnimating = false;
+  }
+
+  /**
    * Replace all pages with a new root
    */
   async setRoot(enteringEl: HTMLElement, config: TransitionConfig = {}): Promise<TransitionResult> {
@@ -243,7 +358,7 @@ export class TransitionController {
       await enteringLifecycle?.onWillEnter?.(event);
 
       // Determine animation parameters
-      const duration = config.duration || this.config.duration || getDefaultDuration(this.platform, direction);
+      const duration = config.duration ?? (this.config.duration || getDefaultDuration(this.platform, direction));
       const easing = this.resolveTransitionEasing(config.easing || this.config.easing, direction);
 
       // Check if we should use View Transitions API
@@ -339,6 +454,46 @@ export class TransitionController {
       this.clearTransitionOnlyStyles(leavingState.element);
       this.clearPagePartTransitionStyles(leavingState);
     }
+  }
+
+  private getAnimationDuration(animation: Animation, fallback: number): number {
+    const duration = animation.effect?.getTiming().duration;
+    return typeof duration === 'number' && Number.isFinite(duration) ? duration : fallback;
+  }
+
+  private async playInteractiveAnimationsTo(targetProgress: 0 | 1, releaseDuration: number): Promise<void> {
+    const transition = this.interactiveBackTransition;
+    if (!transition) {
+      return;
+    }
+
+    if (releaseDuration <= 0) {
+      for (const animation of transition.animations) {
+        const duration = this.getAnimationDuration(animation, transition.duration);
+        animation.pause();
+        animation.currentTime = duration * targetProgress;
+      }
+      return;
+    }
+
+    const finished = transition.animations.map((animation) => {
+      const duration = this.getAnimationDuration(animation, transition.duration);
+      const currentTime = typeof animation.currentTime === 'number' ? animation.currentTime : 0;
+      const targetTime = duration * targetProgress;
+      const distance = Math.abs(targetTime - currentTime);
+
+      if (distance < 1) {
+        animation.currentTime = targetTime;
+        return Promise.resolve();
+      }
+
+      animation.playbackRate = Math.max(distance / releaseDuration, 0.001) * (targetTime >= currentTime ? 1 : -1);
+      animation.play();
+
+      return animation.finished.catch(() => undefined);
+    });
+
+    await Promise.all(finished);
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -12,8 +12,8 @@ export type TransitionPlatform = 'ios' | 'android' | 'auto';
 /** Runtime platform reported by Capacitor when available */
 export type NativePlatform = 'ios' | 'android' | 'web' | 'unknown';
 
-/** Whether edge swipe-back is enabled, disabled, or native-detected */
-export type SwipeBackOption = boolean | 'auto';
+/** Whether the edge swipe-back gesture is enabled, disabled, or native-detected */
+export type SwipeGestureOption = boolean | 'auto';
 
 /** Which parts of the page to animate */
 export type TransitionTarget = 'header' | 'content' | 'footer' | 'all';
@@ -108,22 +108,6 @@ export interface NavigationEvent {
   skipAnimation?: boolean;
 }
 
-/** Details emitted when an edge swipe-back gesture commits */
-export interface SwipeBackEventDetail {
-  /** Direction requested by the gesture */
-  direction: 'back';
-  /** Platform detected from Capacitor at gesture time */
-  platform: NativePlatform;
-  /** Whether Capacitor reports a native installed app runtime */
-  native: boolean;
-  /** Horizontal gesture distance in CSS pixels */
-  deltaX: number;
-  /** Vertical gesture distance in CSS pixels */
-  deltaY: number;
-  /** Horizontal velocity in CSS pixels per millisecond */
-  velocityX: number;
-}
-
 /** Lifecycle hooks for page transitions */
 export interface TransitionLifecycle {
   /** Called before the page becomes visible (before animation) */
@@ -179,7 +163,7 @@ export interface RouterOutletOptions {
   /** Transition configuration */
   transition?: TransitionConfig;
   /** Edge swipe-back gesture support (default: 'auto', native iOS only) */
-  swipeBack?: SwipeBackOption;
+  swipeGesture?: SwipeGestureOption;
 }
 
 /** Page component options */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,6 +9,12 @@ export type TransitionDirection = 'forward' | 'back' | 'root' | 'none';
 /** Platform-specific animation styles */
 export type TransitionPlatform = 'ios' | 'android' | 'auto';
 
+/** Runtime platform reported by Capacitor when available */
+export type NativePlatform = 'ios' | 'android' | 'web' | 'unknown';
+
+/** Whether edge swipe-back is enabled, disabled, or native-detected */
+export type SwipeBackOption = boolean | 'auto';
+
 /** Which parts of the page to animate */
 export type TransitionTarget = 'header' | 'content' | 'footer' | 'all';
 
@@ -43,6 +49,14 @@ export interface TransitionConfig {
   onComplete?: () => void;
   /** Whether to use View Transitions API when available (default: false) */
   useViewTransitions?: boolean;
+}
+
+/** Capacitor native runtime detection result */
+export interface NativePlatformInfo {
+  /** Platform name from Capacitor.getPlatform() when available */
+  platform: NativePlatform;
+  /** Whether Capacitor reports a native installed app runtime */
+  isNative: boolean;
 }
 
 /** Resolved platform type (excludes 'auto') */
@@ -92,6 +106,22 @@ export interface NavigationEvent {
   to: PageState;
   /** Whether animation should be skipped */
   skipAnimation?: boolean;
+}
+
+/** Details emitted when an edge swipe-back gesture commits */
+export interface SwipeBackEventDetail {
+  /** Direction requested by the gesture */
+  direction: 'back';
+  /** Platform detected from Capacitor at gesture time */
+  platform: NativePlatform;
+  /** Whether Capacitor reports a native installed app runtime */
+  native: boolean;
+  /** Horizontal gesture distance in CSS pixels */
+  deltaX: number;
+  /** Vertical gesture distance in CSS pixels */
+  deltaY: number;
+  /** Horizontal velocity in CSS pixels per millisecond */
+  velocityX: number;
 }
 
 /** Lifecycle hooks for page transitions */
@@ -148,6 +178,8 @@ export interface RouterOutletOptions {
   animation?: AnimationBuilder;
   /** Transition configuration */
   transition?: TransitionConfig;
+  /** Edge swipe-back gesture support (default: 'auto', native iOS only) */
+  swipeBack?: SwipeBackOption;
 }
 
 /** Page component options */

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ export type {
   TransitionEasing,
   TransitionConfig,
   TransitionGlobalConfig,
+  NativePlatform,
+  NativePlatformInfo,
+  SwipeBackOption,
+  SwipeBackEventDetail,
   PageState,
   NavigationEvent,
   TransitionLifecycle,
@@ -61,6 +65,9 @@ export {
   VIEW_TRANSITIONS_CSS,
   injectViewTransitionsCSS,
 } from './core/view-transitions';
+
+// Native runtime detection
+export { detectNativePlatform, isNativeBackSwipePlatform } from './core/native-platform';
 
 // Transition controller
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,7 @@ export type {
   TransitionGlobalConfig,
   NativePlatform,
   NativePlatformInfo,
-  SwipeBackOption,
-  SwipeBackEventDetail,
+  SwipeGestureOption,
   PageState,
   NavigationEvent,
   TransitionLifecycle,
@@ -67,7 +66,7 @@ export {
 } from './core/view-transitions';
 
 // Native runtime detection
-export { detectNativePlatform, isNativeBackSwipePlatform } from './core/native-platform';
+export { detectNativePlatform, isNativeSwipeGesturePlatform } from './core/native-platform';
 
 // Transition controller
 export {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,7 +5,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -60,14 +60,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
+    swipeBack?: SwipeBackOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
+  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
 }
 
 /**
@@ -155,7 +157,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';
@@ -170,6 +172,7 @@ declare global {
         duration?: number;
         'keep-in-dom'?: boolean;
         'max-cached'?: number;
+        'swipe-back'?: boolean | 'true' | 'false' | 'auto';
         ref?: unknown;
         children?: unknown;
       };

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,7 +5,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -60,16 +60,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
-    swipeBack?: SwipeBackOption;
+    swipeGesture?: SwipeGestureOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeGesture } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
-  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
+  if (swipeGesture !== undefined) element.setAttribute('swipe-gesture', String(swipeGesture));
 }
 
 /**
@@ -157,7 +157,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';
@@ -172,7 +172,7 @@ declare global {
         duration?: number;
         'keep-in-dom'?: boolean;
         'max-cached'?: number;
-        'swipe-back'?: boolean | 'true' | 'false' | 'auto';
+        'swipe-gesture'?: boolean | 'true' | 'false' | 'auto';
         ref?: unknown;
         children?: unknown;
       };

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -4,7 +4,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -58,14 +58,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
+    swipeBack?: SwipeBackOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
+  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
 }
 
 /**
@@ -120,7 +122,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -4,7 +4,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -58,16 +58,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
-    swipeBack?: SwipeBackOption;
+    swipeGesture?: SwipeGestureOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeGesture } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
-  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
+  if (swipeGesture !== undefined) element.setAttribute('swipe-gesture', String(swipeGesture));
 }
 
 /**
@@ -122,7 +122,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -88,6 +88,8 @@ export function routerOutlet(
       }
       if (newOptions.swipeBack !== undefined) {
         node.setAttribute('swipe-back', String(newOptions.swipeBack));
+      } else {
+        node.removeAttribute('swipe-back');
       }
     },
     destroy(): void {

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -4,7 +4,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -61,20 +61,20 @@ interface RouterOutletOptions {
   maxCached?: number;
   platform?: 'ios' | 'android' | 'auto';
   duration?: number;
-  swipeBack?: SwipeBackOption;
+  swipeGesture?: SwipeGestureOption;
 }
 
 export function routerOutlet(
   node: HTMLElement,
   options: RouterOutletOptions = {},
 ): SvelteActionReturn<RouterOutletOptions> {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeGesture } = options;
 
   node.setAttribute('platform', platform);
   if (duration) node.setAttribute('duration', String(duration));
   node.setAttribute('keep-in-dom', String(keepInDom));
   node.setAttribute('max-cached', String(maxCached));
-  if (swipeBack !== undefined) node.setAttribute('swipe-back', String(swipeBack));
+  if (swipeGesture !== undefined) node.setAttribute('swipe-gesture', String(swipeGesture));
 
   return {
     update(newOptions: RouterOutletOptions): void {
@@ -86,10 +86,10 @@ export function routerOutlet(
       if (newOptions.maxCached !== undefined) {
         node.setAttribute('max-cached', String(newOptions.maxCached));
       }
-      if (newOptions.swipeBack !== undefined) {
-        node.setAttribute('swipe-back', String(newOptions.swipeBack));
+      if (newOptions.swipeGesture !== undefined) {
+        node.setAttribute('swipe-gesture', String(newOptions.swipeGesture));
       } else {
-        node.removeAttribute('swipe-back');
+        node.removeAttribute('swipe-gesture');
       }
     },
     destroy(): void {
@@ -165,7 +165,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Export controller class for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -4,7 +4,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -61,18 +61,20 @@ interface RouterOutletOptions {
   maxCached?: number;
   platform?: 'ios' | 'android' | 'auto';
   duration?: number;
+  swipeBack?: SwipeBackOption;
 }
 
 export function routerOutlet(
   node: HTMLElement,
   options: RouterOutletOptions = {},
 ): SvelteActionReturn<RouterOutletOptions> {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
 
   node.setAttribute('platform', platform);
   if (duration) node.setAttribute('duration', String(duration));
   node.setAttribute('keep-in-dom', String(keepInDom));
   node.setAttribute('max-cached', String(maxCached));
+  if (swipeBack !== undefined) node.setAttribute('swipe-back', String(swipeBack));
 
   return {
     update(newOptions: RouterOutletOptions): void {
@@ -83,6 +85,9 @@ export function routerOutlet(
       }
       if (newOptions.maxCached !== undefined) {
         node.setAttribute('max-cached', String(newOptions.maxCached));
+      }
+      if (newOptions.swipeBack !== undefined) {
+        node.setAttribute('swipe-back', String(newOptions.swipeBack));
       }
     },
     destroy(): void {
@@ -158,7 +163,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Export controller class for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -5,7 +5,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -60,14 +60,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
+    swipeBack?: SwipeBackOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
+  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
 }
 
 /**
@@ -167,7 +169,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -5,7 +5,7 @@
 
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -60,16 +60,16 @@ export function setupRouterOutlet(
     maxCached?: number;
     platform?: 'ios' | 'android' | 'auto';
     duration?: number;
-    swipeBack?: SwipeBackOption;
+    swipeGesture?: SwipeGestureOption;
   } = {},
 ): void {
-  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeBack } = options;
+  const { keepInDom = true, maxCached = 10, platform = 'auto', duration, swipeGesture } = options;
 
   element.setAttribute('platform', platform);
   if (duration) element.setAttribute('duration', String(duration));
   element.setAttribute('keep-in-dom', String(keepInDom));
   element.setAttribute('max-cached', String(maxCached));
-  if (swipeBack !== undefined) element.setAttribute('swipe-back', String(swipeBack));
+  if (swipeGesture !== undefined) element.setAttribute('swipe-gesture', String(swipeGesture));
 }
 
 /**
@@ -169,7 +169,7 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeBackOption } from '../core/types';
+export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';


### PR DESCRIPTION
## What
- Add optional Ionic-style edge swipe-back support to `cap-router-outlet`.
- Support `swipeGesture` / `swipe-gesture` as `true`, `false`, or `auto`.
- Auto-enable only for Capacitor native iOS by default.
- Expose the option through React, Vue, Svelte, and Solid helpers, and document it.

## Why
- Native iOS apps expect an edge swipe gesture for back navigation.
- The gesture should not run on regular web by default, and apps need a JS switch to force-enable or disable it.
- This should follow Ionic's model: internal gesture handling tied to transition progress, not a public fake native event.

## How
- Added Capacitor runtime detection using `Capacitor.isNativePlatform()` and `Capacitor.getPlatform()` when available.
- Added Ionic-style edge gesture thresholds: 50px edge, 10px drag threshold, velocity/distance commit checks, and RTL support.
- The gesture now starts an interactive back transition, tracks finger progress, completes/cancels the animation, then syncs browser history without replaying the transition.
- Removed the `cap-swipe-back` event API and renamed the public option to `swipeGesture` / `swipe-gesture` to match Ionic's shape.

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run verify`
- `cd examples/react-app && bun run build`
- Headless Playwright gesture checks:
  - mocked native iOS Capacitor auto mode drags with the finger and commits back
  - web auto mode blocks the gesture
  - `setSwipeGesture(false)` blocks the gesture
  - aborted swipe cancels and restores the current page

## Not Tested
- Physical iOS device gesture feel; this was validated in a headless browser with mocked Capacitor native iOS runtime.

Implemented by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional iOS edge swipe-back gesture with native-auto detection
  * New `swipe-gesture` attribute and `setSwipeGesture(...)` API to enable/disable/auto the gesture
  * Router initialization helpers gain a `swipeGesture` option across frameworks
  * Interactive back transition support for smoother, interruptible back animations

* **Documentation**
  * README updated with configuration examples and `auto` runtime detection behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-transitions/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->