### PR TITLE
Smooth interactive swipe back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # @capgo/capacitor-transitions
 
-<a href="https://capgo.app/"><img src="https://capgo.app/readme-banner.svg?repo=Cap-go/capacitor-transitions" alt="Capgo - Instant updates for Capacitor" /></a>
+<a href="https://capgo.app/">
+  <img
+    src="https://capgo.app/readme-banner.svg?repo=Cap-go/capacitor-transitions"
+    alt="Capgo - Instant updates for Capacitor"
+  />
+</a>
 
 Framework-agnostic page transitions for Capacitor apps. iOS-style navigation without opinions.
 

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -30,6 +30,7 @@ interface SwipeGesturePointerState {
   startY: number;
   currentX: number;
   currentY: number;
+  width: number;
   startTime: number;
   dragging: boolean;
   transitionStarted: boolean;
@@ -46,6 +47,8 @@ export class CapRouterOutlet extends HTMLElement {
   private pendingPage: HTMLElement | null = null;
   private ignoredNodes = new WeakSet<HTMLElement>();
   private swipeGesturePointer: SwipeGesturePointerState | null = null;
+  private swipeGestureFrame = 0;
+  private swipeGesturePendingStep: number | null = null;
   private swipeGestureListenersActive = false;
   private skipNextHistoryBackTransition = false;
   private swipeBackDepth = 0;
@@ -98,6 +101,8 @@ export class CapRouterOutlet extends HTMLElement {
     this.style.width = '100%';
     this.style.height = '100%';
     this.style.overflow = 'hidden';
+    this.style.touchAction = 'pan-y';
+    this.style.overscrollBehaviorX = 'contain';
     this.lastNavigationHref = this.getCurrentNavigationHref();
     this.lastNavigationPosition = this.getCurrentNavigationPosition();
     this.ownerDocument.defaultView?.addEventListener('popstate', this.handleHistoryPopState);
@@ -473,6 +478,7 @@ export class CapRouterOutlet extends HTMLElement {
     this.removeEventListener('pointerup', this.handleSwipeGesturePointerEnd);
     this.removeEventListener('pointercancel', this.handleSwipeGesturePointerCancel);
     this.swipeGestureListenersActive = false;
+    this.clearQueuedSwipeGestureStep();
     this.swipeGesturePointer = null;
   }
 
@@ -735,12 +741,15 @@ export class CapRouterOutlet extends HTMLElement {
       return;
     }
 
+    const width = Math.max(this.getBoundingClientRect().width, 1);
+
     this.swipeGesturePointer = {
       pointerId: event.pointerId,
       startX: event.clientX,
       startY: event.clientY,
       currentX: event.clientX,
       currentY: event.clientY,
+      width,
       startTime: performance.now(),
       dragging: false,
       transitionStarted: false,
@@ -799,8 +808,7 @@ export class CapRouterOutlet extends HTMLElement {
       }
 
       if (event.cancelable) event.preventDefault();
-      const width = Math.max(this.getBoundingClientRect().width, 1);
-      this.controller.stepInteractiveBack(deltaX / width);
+      this.queueSwipeGestureStep(deltaX / pointer.width);
     }
   };
 
@@ -816,7 +824,7 @@ export class CapRouterOutlet extends HTMLElement {
     const deltaX = this.getSwipeGestureDeltaX(pointer);
     const elapsed = Math.max(performance.now() - pointer.startTime, 1);
     const velocityX = deltaX / elapsed;
-    const width = Math.max(this.getBoundingClientRect().width, 1);
+    const width = pointer.width;
     const step = deltaX / width;
     const shouldCommit =
       pointer.dragging &&
@@ -828,6 +836,12 @@ export class CapRouterOutlet extends HTMLElement {
     const releaseDuration =
       missingDistance > 5 && Math.abs(velocityX) > 0 ? Math.min(missingDistance / Math.abs(velocityX), 540) : 0;
 
+    if (pointer.transitionStarted) {
+      this.flushQueuedSwipeGestureStep();
+    } else {
+      this.clearQueuedSwipeGestureStep();
+    }
+
     this.releaseSwipeGesturePointer(event.pointerId);
 
     void this.finishSwipeGestureBack(shouldCommit, releaseDuration);
@@ -838,6 +852,7 @@ export class CapRouterOutlet extends HTMLElement {
   };
 
   private cancelSwipeGesturePointer(pointerId: number): void {
+    this.clearQueuedSwipeGestureStep();
     this.releaseSwipeGesturePointer(pointerId);
   }
 
@@ -862,10 +877,53 @@ export class CapRouterOutlet extends HTMLElement {
     }
 
     this.releaseSwipeGesturePointer(pointerId);
+    this.clearQueuedSwipeGestureStep();
 
     if (pointer.transitionStarted) {
       void this.finishSwipeGestureBack(false, 0);
     }
+  }
+
+  private queueSwipeGestureStep(step: number): void {
+    this.swipeGesturePendingStep = step;
+
+    if (this.swipeGestureFrame !== 0) {
+      return;
+    }
+
+    const win = this.ownerDocument.defaultView;
+    if (!win) {
+      this.flushQueuedSwipeGestureStep();
+      return;
+    }
+
+    this.swipeGestureFrame = win.requestAnimationFrame(() => {
+      this.swipeGestureFrame = 0;
+      this.flushQueuedSwipeGestureStep();
+    });
+  }
+
+  private flushQueuedSwipeGestureStep(): void {
+    const step = this.swipeGesturePendingStep;
+    this.swipeGesturePendingStep = null;
+
+    if (this.swipeGestureFrame !== 0) {
+      this.ownerDocument.defaultView?.cancelAnimationFrame(this.swipeGestureFrame);
+      this.swipeGestureFrame = 0;
+    }
+
+    if (step !== null) {
+      this.controller.stepInteractiveBack(step);
+    }
+  }
+
+  private clearQueuedSwipeGestureStep(): void {
+    if (this.swipeGestureFrame !== 0) {
+      this.ownerDocument.defaultView?.cancelAnimationFrame(this.swipeGestureFrame);
+      this.swipeGestureFrame = 0;
+    }
+
+    this.swipeGesturePendingStep = null;
   }
 
   private async finishSwipeGestureBack(shouldComplete: boolean, releaseDuration: number): Promise<void> {

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -101,7 +101,6 @@ export class CapRouterOutlet extends HTMLElement {
     this.style.width = '100%';
     this.style.height = '100%';
     this.style.overflow = 'hidden';
-    this.style.touchAction = 'pan-y';
     this.style.overscrollBehaviorX = 'contain';
     this.lastNavigationHref = this.getCurrentNavigationHref();
     this.lastNavigationPosition = this.getCurrentNavigationPosition();
@@ -479,6 +478,9 @@ export class CapRouterOutlet extends HTMLElement {
     this.removeEventListener('pointercancel', this.handleSwipeGesturePointerCancel);
     this.swipeGestureListenersActive = false;
     this.clearQueuedSwipeGestureStep();
+    if (this.swipeGesturePointer?.transitionStarted) {
+      this.controller.cancelInteractiveBack();
+    }
     this.swipeGesturePointer = null;
   }
 

--- a/src/core/transition-controller.ts
+++ b/src/core/transition-controller.ts
@@ -42,7 +42,9 @@ interface InteractiveBackTransition {
   enteringState: PageState;
   leavingState: PageState;
   animations: Animation[];
+  animationDurations: number[];
   duration: number;
+  progress: number;
 }
 
 /**
@@ -207,13 +209,16 @@ export class TransitionController {
       animation.pause();
       animation.currentTime = 0;
     }
+    const animationDurations = animations.map((animation) => this.getAnimationDuration(animation, duration));
 
     this.currentAnimations = animations;
     this.interactiveBackTransition = {
       enteringState,
       leavingState,
       animations,
+      animationDurations,
       duration,
+      progress: 0,
     };
 
     return true;
@@ -229,9 +234,14 @@ export class TransitionController {
     }
 
     const progress = Math.max(0, Math.min(step, 0.9999));
-    for (const animation of transition.animations) {
-      const duration = this.getAnimationDuration(animation, transition.duration);
-      animation.pause();
+    if (Math.abs(progress - transition.progress) < 0.0005) {
+      return;
+    }
+
+    transition.progress = progress;
+
+    for (const [index, animation] of transition.animations.entries()) {
+      const duration = transition.animationDurations[index] ?? transition.duration;
       animation.currentTime = duration * progress;
     }
   }
@@ -468,16 +478,17 @@ export class TransitionController {
     }
 
     if (releaseDuration <= 0) {
-      for (const animation of transition.animations) {
-        const duration = this.getAnimationDuration(animation, transition.duration);
+      transition.progress = targetProgress;
+      for (const [index, animation] of transition.animations.entries()) {
+        const duration = transition.animationDurations[index] ?? transition.duration;
         animation.pause();
         animation.currentTime = duration * targetProgress;
       }
       return;
     }
 
-    const finished = transition.animations.map((animation) => {
-      const duration = this.getAnimationDuration(animation, transition.duration);
+    const finished = transition.animations.map((animation, index) => {
+      const duration = transition.animationDurations[index] ?? transition.duration;
       const currentTime = typeof animation.currentTime === 'number' ? animation.currentTime : 0;
       const targetTime = duration * targetProgress;
       const distance = Math.abs(targetTime - currentTime);
@@ -494,6 +505,7 @@ export class TransitionController {
     });
 
     await Promise.all(finished);
+    transition.progress = targetProgress;
   }
 
   /**


### PR DESCRIPTION
## What
- Batch interactive swipe-back progress updates with `requestAnimationFrame` so multiple pointer events only drive one animation step per frame.
- Cache animation durations and gesture width during an interactive swipe to avoid repeated timing/layout reads while the finger moves.
- Keep horizontal overscroll contained on the router outlet without forcing `touch-action` on the full outlet, so descendant horizontal scrollers can keep working.
- Cancel an active interactive swipe cleanly if the gesture option is disabled mid-drag.
- Apply the repo formatter's README banner markup change; content is unchanged.

## Why
- The swipe-back gesture can feel laggy because each `pointermove` was immediately walking every WAAPI animation and reading animation timing/layout data.
- Native-feeling interactive gestures should follow the display frame cadence and avoid doing extra work between frames.

## How
- Queue the latest swipe progress and flush it once per animation frame, with a final flush on release.
- Precompute per-animation durations when the interactive transition starts.
- Reuse the gesture width captured on pointer down for progress and velocity calculations.
- Keep the existing Web Animations path instead of switching to View Transitions, because this gesture needs to follow the user's finger and remain reversible.

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run verify`
- `cd examples/react-app && bun run build`
- Headless React smoke: 30 synthetic pointer moves produce one frame update before release; swipe completes back to root; root swipe still creates zero animations; outlet keeps `touch-action: auto` and `overscroll-behavior-x: contain`; disabling swipe mid-drag cancels the controller and clears the pointer.

## Not Tested
- Physical iOS/Android device frame-time profile. The browser gesture path and frame batching behavior were verified headlessly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More stable edge swipe-back gesture and smoother interactive back transitions for improved responsiveness.
* **Documentation**
  * Updated README banner markup structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-transitions/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->