### PR TITLE
feat: allow forward animation for root navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ const outlet = document.querySelector('cap-router-outlet');
 outlet.push(newPageElement);
 outlet.pop();
 outlet.setRoot(newRootElement);
+outlet.setRoot(onboardingDoneElement, { direction: 'forward' });
+
+// For router-driven replace/reset flows, reset the stack but keep a forward slide.
+outlet.setNavigation('root', 'forward');
+yourRouter.replace('/home');
 ```
 
 ### React
@@ -77,7 +82,13 @@ outlet.setRoot(newRootElement);
 ```tsx
 import { useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { initTransitions, setDirection, setupPage, setupRouterOutlet } from '@capgo/capacitor-transitions/react';
+import {
+  initTransitions,
+  setDirection,
+  setNavigation,
+  setupPage,
+  setupRouterOutlet,
+} from '@capgo/capacitor-transitions/react';
 import '@capgo/capacitor-transitions';
 
 // Initialize once at app startup
@@ -117,6 +128,11 @@ function HomePage() {
   const goToDetails = (id: number) => {
     setDirection('forward');
     navigate(`/details/${id}`);
+  };
+
+  const finishOnboarding = () => {
+    setNavigation('root', 'forward');
+    navigate('/home', { replace: true });
   };
 
   return (
@@ -368,7 +384,7 @@ Drive both packages from the same router actions:
 
 ```typescript
 import { NativeNavigation } from '@capgo/native-navigation';
-import { setDirection } from '@capgo/capacitor-transitions/react';
+import { setDirection, setNavigation } from '@capgo/capacitor-transitions/react';
 import { router } from './router';
 
 await NativeNavigation.addListener('navbarBack', () => {
@@ -383,6 +399,16 @@ async function openMessage(id: string) {
   await NativeNavigation.setNavbar({
     title: 'Message',
     backButton: { visible: true, title: 'Inbox' },
+  });
+}
+
+async function finishOnboarding() {
+  setNavigation('root', 'forward');
+  router.replace('/inbox');
+
+  await NativeNavigation.setNavbar({
+    title: 'Inbox',
+    backButton: { visible: false },
   });
 }
 ```
@@ -409,7 +435,8 @@ Methods:
 
 - `push(element, config?)` - Navigate forward to new page
 - `pop(config?)` - Navigate back
-- `setRoot(element, config?)` - Replace navigation stack
+- `setRoot(element, config?)` - Replace navigation stack. Pass `{ direction: 'forward' }` to reset the stack with a forward slide.
+- `setNavigation(action, direction?)` - Set the stack action and animation direction for the next router-driven navigation
 - `setSwipeGesture(true | false | 'auto')` - Enable, disable, or auto-detect edge swipe-back gesture
 
 `swipe-gesture="auto"` uses Capacitor's runtime helpers (`Capacitor.isNativePlatform()` and `Capacitor.getPlatform()`) and enables the gesture only for native iOS apps. Use `swipe-gesture="true"` to force it on any platform or `swipe-gesture="false"` to disable it.
@@ -452,6 +479,17 @@ Footer container. Use with `slot="footer"`.
 | `'root'`    | Replace animation (fade)               |
 | `'none'`    | No animation                           |
 
+### Navigation Actions
+
+Navigation actions control the recorded stack independently from the visual animation. This is useful when a router `replace` or native navigation reset should feel like a forward page push but must not leave a swipe-back entry behind.
+
+```typescript
+setNavigation('root', 'forward');
+router.replace('/home');
+```
+
+`setNavigation('root', 'forward')` clears the transition stack after the navigation and plays the forward animation. Swipe-back stays disabled because there is no previous page.
+
 ### Helper Functions
 
 All framework bindings export these helper functions:
@@ -462,6 +500,9 @@ initTransitions({ platform: 'auto' });
 
 // Set the direction for the next navigation
 setDirection('forward' | 'back' | 'root' | 'none');
+
+// Set the stack action and animation direction for the next navigation
+setNavigation('forward' | 'back' | 'root' | 'none', 'forward' | 'back' | 'root' | 'none');
 
 // Set up a router outlet element
 setupRouterOutlet(element, options);
@@ -498,6 +539,7 @@ const controller = createTransitionController({
 await controller.push(element, { direction: 'forward' });
 await controller.pop({ direction: 'back' });
 await controller.setRoot(element, { direction: 'root' });
+await controller.setRoot(element, { direction: 'forward' });
 
 // Lifecycle hooks
 controller.registerLifecycle('page-id', {

--- a/README.md
+++ b/README.md
@@ -502,7 +502,8 @@ initTransitions({ platform: 'auto' });
 setDirection('forward' | 'back' | 'root' | 'none');
 
 // Set the stack action and animation direction for the next navigation
-setNavigation('forward' | 'back' | 'root' | 'none', 'forward' | 'back' | 'root' | 'none');
+setNavigation('root', 'forward');
+setNavigation('root'); // direction is optional and defaults to the same value as the stack action.
 
 // Set up a router outlet element
 setupRouterOutlet(element, options);

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-ro
 import {
   initTransitions,
   setDirection,
+  setNavigation,
   setupPage,
   setupRouterOutlet,
 } from '@capgo/capacitor-transitions/react'
@@ -140,7 +141,7 @@ function NestedPage() {
   }
 
   const goHome = () => {
-    setDirection('root')
+    setNavigation('root', 'forward')
     navigate('/')
   }
 
@@ -159,9 +160,7 @@ function NestedPage() {
           <h2>Deeply Nested View</h2>
           <p>This is a nested page to demonstrate multi-level navigation.</p>
 
-          <button className="primary-button" onClick={goHome}>
-            Go to Root (with fade)
-          </button>
+          <button className="primary-button" onClick={goHome}>Reset to Home</button>
         </div>
       </cap-content>
     </cap-page>

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -5,7 +5,7 @@
  */
 
 import { isNativeSwipeGesturePlatform } from '../core/native-platform';
-import { getDefaultNavigationDirection, setOutletNavigationIntent } from '../core/navigation';
+import { getDefaultNavigationDirection, setOutletDirectionIntent, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
 import type {
@@ -962,7 +962,7 @@ export class CapRouterOutlet extends HTMLElement {
 
     if (shouldUseHistory) {
       this.skipNextHistoryBackTransition = true;
-      this.dataset.direction = 'back';
+      setOutletDirectionIntent(this, 'back');
       window.history.back();
       return;
     }

--- a/src/components/cap-router-outlet.ts
+++ b/src/components/cap-router-outlet.ts
@@ -5,12 +5,14 @@
  */
 
 import { isNativeSwipeGesturePlatform } from '../core/native-platform';
+import { getDefaultNavigationDirection, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
 import type {
   TransitionConfig,
   TransitionGlobalConfig,
   TransitionDirection,
+  NavigationAction,
   PageState,
   SwipeGestureOption,
 } from '../core/types';
@@ -243,10 +245,16 @@ export class CapRouterOutlet extends HTMLElement {
     // Determine direction from page, outlet, or default to forward.
     // Framework adapters can set direction on the outlet right before navigation.
     const outletDirection = this.dataset.direction as TransitionDirection | undefined;
+    const outletNavigationAction = this.dataset.navigationAction as NavigationAction | undefined;
     const explicitDirection = (page.dataset.direction as TransitionDirection | undefined) || outletDirection;
+    const explicitNavigationAction =
+      (page.dataset.navigationAction as NavigationAction | undefined) || outletNavigationAction;
     const direction = this.resolveNavigationDirection(explicitDirection);
     if (outletDirection) {
       delete this.dataset.direction;
+    }
+    if (outletNavigationAction) {
+      delete this.dataset.navigationAction;
     }
     const skipTransition = this.skipNextHistoryBackTransition && direction === 'back';
     this.skipNextHistoryBackTransition = false;
@@ -258,9 +266,13 @@ export class CapRouterOutlet extends HTMLElement {
     this.pendingPage = page;
 
     try {
-      const result = await this.controller.navigate(page, { direction, duration: skipTransition ? 0 : undefined });
+      const result = await this.controller.navigate(page, {
+        direction,
+        navigationAction: explicitNavigationAction,
+        duration: skipTransition ? 0 : undefined,
+      });
       if (result.success) {
-        this.recordCompletedNavigation(direction, { hadPageBefore });
+        this.recordCompletedNavigation(explicitNavigationAction ?? direction, { hadPageBefore });
       }
     } finally {
       this.pendingPage = null;
@@ -414,6 +426,16 @@ export class CapRouterOutlet extends HTMLElement {
     } else {
       this.updateSwipeGestureListeners();
     }
+  }
+
+  /**
+   * Set the navigation stack action and animation direction for the next router-driven navigation.
+   */
+  setNavigation(
+    action: NavigationAction,
+    direction: TransitionDirection = getDefaultNavigationDirection(action),
+  ): void {
+    setOutletNavigationIntent(this, action, direction);
   }
 
   /**

--- a/src/core/navigation.test.ts
+++ b/src/core/navigation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { setOutletDirectionIntent, setOutletNavigationIntent } from './navigation';
+import { createTransitionController } from './transition-controller';
+
+function createMockAnimation(): Animation {
+  return {
+    cancel: vi.fn(),
+    effect: {
+      getTiming: () => ({ duration: 0 }),
+    },
+    finished: Promise.resolve(),
+    pause: vi.fn(),
+    play: vi.fn(),
+    currentTime: 0,
+    playbackRate: 1,
+  } as unknown as Animation;
+}
+
+function createMockElement() {
+  const style = {
+    removeProperty: vi.fn(),
+  } as unknown as CSSStyleDeclaration;
+
+  return {
+    classList: {
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+    ownerDocument: {
+      dir: 'ltr',
+      documentElement: {
+        dir: 'ltr',
+      },
+    },
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    remove: vi.fn(),
+    style,
+    animate: vi.fn(() => createMockAnimation()),
+  } as unknown as HTMLElement & {
+    animate: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('navigation intents', () => {
+  it('stores and clears router navigation intent on outlets', () => {
+    const outlet = { dataset: {} } as HTMLElement;
+
+    setOutletNavigationIntent(outlet, 'root', 'forward');
+
+    expect(outlet.dataset.navigationAction).toBe('root');
+    expect(outlet.dataset.direction).toBe('forward');
+
+    setOutletDirectionIntent(outlet, 'back');
+
+    expect(outlet.dataset.navigationAction).toBeUndefined();
+    expect(outlet.dataset.direction).toBe('back');
+  });
+
+  it('can reset the stack while using the forward animation', async () => {
+    const controller = createTransitionController({ platform: 'ios' });
+    const firstPage = createMockElement();
+    const secondPage = createMockElement();
+
+    await controller.setRoot(firstPage, { duration: 0 });
+    await controller.setRoot(secondPage, { direction: 'forward', duration: 0 });
+
+    expect(controller.stack).toHaveLength(1);
+    expect(controller.currentPage?.element).toBe(secondPage);
+    expect(firstPage.remove).not.toHaveBeenCalled();
+    expect(secondPage.animate).toHaveBeenCalled();
+    expect(secondPage.animate.mock.calls[0][0]).toEqual([
+      { transform: 'translate3d(99.5%, 0, 0)' },
+      { transform: 'translate3d(0%, 0, 0)' },
+    ]);
+  });
+});

--- a/src/core/navigation.ts
+++ b/src/core/navigation.ts
@@ -1,0 +1,21 @@
+import type { NavigationAction, TransitionDirection } from './types';
+
+export function getDefaultNavigationDirection(action: NavigationAction): TransitionDirection {
+  return action;
+}
+
+export function setOutletDirectionIntent(outlet: Element, direction: TransitionDirection): void {
+  const element = outlet as HTMLElement;
+  element.dataset.direction = direction;
+  delete element.dataset.navigationAction;
+}
+
+export function setOutletNavigationIntent(
+  outlet: Element,
+  action: NavigationAction,
+  direction: TransitionDirection = getDefaultNavigationDirection(action),
+): void {
+  const element = outlet as HTMLElement;
+  element.dataset.navigationAction = action;
+  element.dataset.direction = direction;
+}

--- a/src/core/transition-controller.ts
+++ b/src/core/transition-controller.ts
@@ -20,6 +20,8 @@ import type {
   NavigationEvent,
   TransitionLifecycle,
   TransitionAnimationOptions,
+  NavigationAction,
+  TransitionDirection,
 } from './types';
 import {
   supportsViewTransitions,
@@ -297,7 +299,11 @@ export class TransitionController {
    * Replace all pages with a new root
    */
   async setRoot(enteringEl: HTMLElement, config: TransitionConfig = {}): Promise<TransitionResult> {
-    return this.navigate(enteringEl, { ...config, direction: 'root' });
+    return this.navigate(enteringEl, {
+      ...config,
+      direction: config.direction ?? 'root',
+      navigationAction: 'root',
+    });
   }
 
   /**
@@ -305,14 +311,15 @@ export class TransitionController {
    */
   async navigate(enteringEl: HTMLElement, config: TransitionConfig = {}): Promise<TransitionResult> {
     const direction = config.direction || 'forward';
+    const navigationAction = this.resolveNavigationAction(direction, config.navigationAction);
     const enteringState = this.createPageState(enteringEl);
     const leavingState = this.currentPage;
 
     return this.navigateWithStates(enteringState, leavingState, config, () => {
-      if (direction === 'root') {
+      if (navigationAction === 'root') {
         // Clear the stack and set new root
         this.pageStack = [enteringState];
-      } else if (direction === 'back' && this.pageStack.length > 0) {
+      } else if (navigationAction === 'back' && this.pageStack.length > 0) {
         // Routers usually create a fresh element for the destination route.
         // Drop both the leaving page and the stale cached destination so the
         // internal stack mirrors the visible route stack.
@@ -323,11 +330,33 @@ export class TransitionController {
           this.lifecycleCallbacks.delete(staleEnteringState.id);
         }
         this.pageStack.push(enteringState);
+      } else if (navigationAction === 'none' && this.pageStack.length > 0) {
+        const staleState = this.pageStack.pop();
+        if (staleState && staleState.element !== enteringState.element) {
+          staleState.element.remove();
+          this.lifecycleCallbacks.delete(staleState.id);
+        }
+        this.pageStack.push(enteringState);
       } else {
         // Push new page onto stack
         this.pageStack.push(enteringState);
       }
     });
+  }
+
+  private resolveNavigationAction(
+    direction: TransitionDirection,
+    navigationAction: NavigationAction | undefined,
+  ): NavigationAction {
+    if (navigationAction) {
+      return navigationAction;
+    }
+
+    if (direction === 'root' || direction === 'back') {
+      return direction;
+    }
+
+    return 'forward';
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,6 +6,9 @@
 /** Direction of the navigation transition */
 export type TransitionDirection = 'forward' | 'back' | 'root' | 'none';
 
+/** Navigation stack action to record independently from the animation direction */
+export type NavigationAction = 'forward' | 'back' | 'root' | 'none';
+
 /** Platform-specific animation styles */
 export type TransitionPlatform = 'ios' | 'android' | 'auto';
 
@@ -37,6 +40,8 @@ export interface TransitionConfig {
   easing?: TransitionEasing;
   /** Direction of transition */
   direction?: TransitionDirection;
+  /** Navigation stack action (default: follows direction, except 'none' keeps push behavior for compatibility) */
+  navigationAction?: NavigationAction;
   /** Which elements to animate (default: 'all') */
   targets?: TransitionTarget[];
   /** Custom animation keyframes for entering element */

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type { CapRouterOutlet, CapPage, CapHeader, CapContent, CapFooter } from 
 
 export type {
   TransitionDirection,
+  NavigationAction,
   TransitionPlatform,
   ResolvedPlatform,
   TransitionTarget,

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -3,9 +3,16 @@
  * Helper functions for using web components in React
  */
 
+import { getDefaultNavigationDirection, setOutletDirectionIntent, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+import type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -44,7 +51,23 @@ export function setDirection(direction: TransitionDirection): void {
 
   if (typeof document !== 'undefined') {
     for (const outlet of document.querySelectorAll('cap-router-outlet')) {
-      (outlet as HTMLElement).dataset.direction = direction;
+      setOutletDirectionIntent(outlet, direction);
+    }
+  }
+}
+
+/**
+ * Set the navigation action and animation direction for the next router navigation.
+ */
+export function setNavigation(
+  action: NavigationAction,
+  direction: TransitionDirection = getDefaultNavigationDirection(action),
+): void {
+  globalDirection = direction;
+
+  if (typeof document !== 'undefined') {
+    for (const outlet of document.querySelectorAll('cap-router-outlet')) {
+      setOutletNavigationIntent(outlet, action, direction);
     }
   }
 }
@@ -157,7 +180,13 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+export type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';
@@ -189,10 +218,13 @@ interface CapTransitionsIntrinsicElements {
     'keep-in-dom'?: Booleanish;
     'max-cached'?: number | string;
     'swipe-gesture'?: boolean | 'true' | 'false' | 'auto';
+    'data-direction'?: 'forward' | 'back' | 'root' | 'none';
+    'data-navigation-action'?: 'forward' | 'back' | 'root' | 'none';
   };
   'cap-page': CapElementAttributes & {
     'cache-scroll'?: Booleanish;
     'data-direction'?: 'forward' | 'back' | 'root' | 'none';
+    'data-navigation-action'?: 'forward' | 'back' | 'root' | 'none';
   };
   'cap-header': CapElementAttributes & {
     translucent?: Booleanish;

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -2,9 +2,16 @@
  * Solid bindings for @capgo/capacitor-transitions
  */
 
+import { getDefaultNavigationDirection, setOutletDirectionIntent, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+import type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -43,7 +50,23 @@ export function setDirection(direction: TransitionDirection): void {
 
   if (typeof document !== 'undefined') {
     for (const outlet of document.querySelectorAll('cap-router-outlet')) {
-      (outlet as HTMLElement).dataset.direction = direction;
+      setOutletDirectionIntent(outlet, direction);
+    }
+  }
+}
+
+/**
+ * Set the navigation action and animation direction for the next router navigation.
+ */
+export function setNavigation(
+  action: NavigationAction,
+  direction: TransitionDirection = getDefaultNavigationDirection(action),
+): void {
+  globalDirection = direction;
+
+  if (typeof document !== 'undefined') {
+    for (const outlet of document.querySelectorAll('cap-router-outlet')) {
+      setOutletNavigationIntent(outlet, action, direction);
     }
   }
 }
@@ -122,7 +145,13 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+export type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -2,9 +2,16 @@
  * Svelte bindings for @capgo/capacitor-transitions
  */
 
+import { getDefaultNavigationDirection, setOutletDirectionIntent, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+import type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -43,7 +50,23 @@ export function setDirection(direction: TransitionDirection): void {
 
   if (typeof document !== 'undefined') {
     for (const outlet of document.querySelectorAll('cap-router-outlet')) {
-      (outlet as HTMLElement).dataset.direction = direction;
+      setOutletDirectionIntent(outlet, direction);
+    }
+  }
+}
+
+/**
+ * Set the navigation action and animation direction for the next router navigation.
+ */
+export function setNavigation(
+  action: NavigationAction,
+  direction: TransitionDirection = getDefaultNavigationDirection(action),
+): void {
+  globalDirection = direction;
+
+  if (typeof document !== 'undefined') {
+    for (const outlet of document.querySelectorAll('cap-router-outlet')) {
+      setOutletNavigationIntent(outlet, action, direction);
     }
   }
 }
@@ -165,7 +188,13 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+export type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Export controller class for advanced usage
 export { TransitionController } from '../core/transition-controller';

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -3,9 +3,16 @@
  * Helper functions for using web components in Vue
  */
 
+import { getDefaultNavigationDirection, setOutletDirectionIntent, setOutletNavigationIntent } from '../core/navigation';
 import type { TransitionController } from '../core/transition-controller';
 import { createTransitionController } from '../core/transition-controller';
-import type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+import type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Ensure web components are registered
 import '../components';
@@ -44,7 +51,23 @@ export function setDirection(direction: TransitionDirection): void {
 
   if (typeof document !== 'undefined') {
     for (const outlet of document.querySelectorAll('cap-router-outlet')) {
-      (outlet as HTMLElement).dataset.direction = direction;
+      setOutletDirectionIntent(outlet, direction);
+    }
+  }
+}
+
+/**
+ * Set the navigation action and animation direction for the next router navigation.
+ */
+export function setNavigation(
+  action: NavigationAction,
+  direction: TransitionDirection = getDefaultNavigationDirection(action),
+): void {
+  globalDirection = direction;
+
+  if (typeof document !== 'undefined') {
+    for (const outlet of document.querySelectorAll('cap-router-outlet')) {
+      setOutletNavigationIntent(outlet, action, direction);
     }
   }
 }
@@ -169,7 +192,13 @@ export function createTransitionNavigate(
 }
 
 // Re-export types
-export type { TransitionGlobalConfig, TransitionDirection, NavigationEvent, SwipeGestureOption } from '../core/types';
+export type {
+  TransitionGlobalConfig,
+  TransitionDirection,
+  NavigationEvent,
+  SwipeGestureOption,
+  NavigationAction,
+} from '../core/types';
 
 // Export controller for advanced usage
 export { TransitionController } from '../core/transition-controller';


### PR DESCRIPTION
## What
- Add a navigation action separate from animation direction so root/reset navigation can animate forward.
- Add `setNavigation(action, direction?)` to the router outlet and React/Vue/Svelte/Solid helpers.
- Document root-with-forward usage, including the native navigation pairing, and update the React example to exercise it.
- Add regression coverage for stack reset with forward animation.

## Why
- Some flows need to replace/reset navigation state while still feeling like a native forward push, for example onboarding completion or native navigation resets.
- Using `direction: root` forced a fade and using `direction: forward` left a swipe-back entry behind.

## How
- Introduced `NavigationAction` and `TransitionConfig.navigationAction` so stack bookkeeping can be independent from visual direction.
- `setRoot(element, { direction: "forward" })` now keeps root stack behavior while playing the requested animation.
- `setNavigation("root", "forward")` stores the next router navigation intent on outlets, then the outlet records root depth while passing forward animation direction to the controller.

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run test`
- `bun run verify`
- `cd examples/react-app && bun run build`
- Headless browser smoke test on the React example: navigated `/` -> `/details/1` -> `/nested/1`, clicked `Reset to Home`, confirmed URL `/`, outlet stack length `1`, `canGoBack` `false`, and entering page forward slide keyframes were used.

## Not Tested
- Native iOS device gesture feel for this exact reset flow; local browser verification covered the DOM stack/action behavior and animation keyframes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced explicit navigation actions (including root/none) and a helper to set action + optional animation direction to control stack behavior and resets.
* **Documentation**
  * Expanded README, API reference, and examples to show stack-reset semantics, new navigation helper usage, and updated quick-starts across frameworks.
* **Tests**
  * Added tests covering navigation intent handling and transition behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-transitions/pull/21)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->