### PR TITLE
[codex] Setup Node for mobile workflows

### DIFF
--- a/.github/workflows/build_mobile_android.yml
+++ b/.github/workflows/build_mobile_android.yml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - name: Validate tag
         run: |
           git fetch --all --tags

--- a/.github/workflows/build_mobile_ios.yml
+++ b/.github/workflows/build_mobile_ios.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - name: Validate tag
         run: |
           git fetch --all --tags

--- a/.github/workflows/deploy_capgo.yml
+++ b/.github/workflows/deploy_capgo.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun i

--- a/README.md
+++ b/README.md
@@ -636,6 +636,8 @@ npm run dev
 
 The repository also includes a Capacitor shell for testing the React demo on real devices and through Capgo. It uses the app id `app.capgo.capacitor.transitions`, app name `Capgo Transitions`, and `examples/react-app/dist` as the native web bundle.
 
+Capacitor CLI requires Node.js 22 or newer.
+
 To build and copy the demo into the native projects:
 
 ```bash
@@ -655,7 +657,7 @@ To deploy an OTA bundle to Capgo:
 
 ```bash
 npm run build:mobile
-npx @capgo/cli@latest bundle upload --channel dev --delta
+npx @capgo/cli@latest bundle upload app.capgo.capacitor.transitions --channel dev --delta
 ```
 
 ## License


### PR DESCRIPTION
## What
- Add Node 24 setup to the mobile Android, iOS, and Capgo deploy workflows.
- Document the Node.js 22+ requirement for local Capacitor CLI usage.
- Include the Capgo app id in the README bundle upload example.

## Why
- Capacitor CLI requires Node.js >=22.0.0, and the mobile workflows could otherwise run under the runner default Node version.

## How
- Reused the existing actions/setup-node@v6 / node-version 24.x pattern from the main workflows.
- Kept Bun for installs and commands.

## Testing
- bun run lint
- bun run verify

## Not Tested
- Manual workflow_dispatch runs for the mobile build/deploy workflows were not executed because they require release tags and signing/deploy secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Mobile Demo App setup guide with Node.js version requirements and prerequisites for development.
  * Enhanced Capgo OTA deployment command documentation for clarity.

* **Chores**
  * Improved mobile build pipelines for Android and iOS with Node.js runtime setup.
  * Optimized Capgo deployment workflow with Node.js environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-transitions/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->